### PR TITLE
Fix Windows build issue for _xgetbv

### DIFF
--- a/Source/Core/Common/x64CPUDetect.cpp
+++ b/Source/Core/Common/x64CPUDetect.cpp
@@ -48,7 +48,11 @@ static u64 _xgetbv_fix(u32 index)
 	__asm__ __volatile__("xgetbv" : "=a"(eax), "=d"(edx) : "c"(index));
 	return ((u64)edx << 32) | eax;
 }
-
+#else
+static u64 _xgetbv_fix(u32 index)
+{
+	return _xgetbv(index);
+}
 #endif // ifndef _WIN32
 
 CPUInfo cpu_info;


### PR DESCRIPTION
This fixes a Windows build issue (undefined symbol) that arose due to this commit: https://github.com/TASLabz/dolphin-lua-core/commit/52ed7a4b1b34447bdf3cdc0490614f9e9c8dec97

Surprised it went this long without anyone noticing!