### PR TITLE
WiiMote Lua support and other changes

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -31,16 +31,6 @@ WriteValueString(memoryAddress as Number, text as String) //Writes the string to
 
 GetPointerNormal(memoryAddress as Number) //Reads the pointer address from the memory, checks if its valid and if so returns the normal address. You can use this function for example to get Links Pointer from the address 0x3ad860. To the return value you simply need to add the offset 0x34E4 and then do a ReadValueFloat with the resulting address to get Links speed (in TWW)
 
-PressButton(Button as String) //Presses the indicated button down, can call this with "Start" for example to press the Start button down. This is a bit buggy still and Buttons need to be pressed every frame or they are automatically released
-
-ReleaseButton(Button as String) //Releases the indicated button. Not really needed atm cause buttons are pressed for only 1 frame
-
-SetMainStickX(pos as Number) //Sets the main control stick X Pos
-SetMainStickY(pos as Number) //Sets the main control stick Y Pos
-
-SetCStickX(pos as Number) //Sets the C-Stick X Pos
-SetCStickY(pos as Number)  //Sets the C-Stick Y Pos
-
 SaveState(useSlot as Boolean, slotID/stateName as Number/String) //Saves the current state in the indicated slot number or fileName
 LoadState(useSlot as Boolean, slotID/stateName as Number/String) //Loads the state from the indicated slot number or fileName
 
@@ -50,8 +40,80 @@ GetInputFrameCount() //Returns the current input frame count
 
 MsgBox(message as String, delayMS as Number) //Dolphin will show the indicated message in the upper-left corner for the indicated length (in milliseconds). Default length is 5 seconds
 SetScreenText(message as String) //Displays Text on Screen
+RenderText(text, start_x, start_y, colour, size) // Displays custom text on screen. (0,0) is the top left. Colour is the hex code 0xRRGGBB. The regular size is 11.
 
 CancelScript() //Cancels the script
+```
+
+For the following input/controller functions:
+- ControllerID corresponds to the controller you want to press inputs on
+- 0 to 3 correspond to GameCube controllers 1 to 4
+- 4 to 7 correspond to WiiMotes 1 to 4
+- This parameter is optional. If no ID is given (or -1), the function will apply to all controllers
+- The Classic Controller is currently unsupported
+- If the specified controller doesn't have the specified button, or the button is an invalid string, then the function call will be ignored
+- For the IR functions, (0, 0) is the top-right of the screen
+- Functions with input ranges have undefined behavior when provided inputs outside that range
+
+```
+PressButton(Button, ControllerID)
+-- Presses a button for the next input poll
+-- Button is one of the following: "A", "B", "X", "Y", "Z", "L", "ZL", "R", "ZR", "Start", "UP" or "D-Up", "DOWN" or "D-Down", "LEFT" or "D-Left", "RIGHT" or "D-Right", "C", "+", "-", "HOME", "1", "2"
+- For GameCube controllers, "L" and "R" set the shoulder button analog to 255.
+
+ReleaseButton(Button, ControllerID)
+-- Ensures the button is not pressed on the next input poll
+
+GetWiimoteKey(ControllerID)
+-- Returns the controller for the current input poll and a string containing its extension decryption key
+-- The key will be all 0s if the Wiimote does not have an extension
+-- e.g. cID, key = GetWiimoteKey(4)
+
+SetIRX(X, ControllerID)
+SetIRY(Y, ControllerID)
+-- Sets the IR X/Y value of the provided controller
+-- X/Y is an integer between 0 and 1023 (inclusive)
+
+GetIR(ControllerID)
+-- Returns the IR coordinates of the specified controller if the current input poll corresponds to that controller, otherwise it returns nil
+-- e.g. x, y = GetIR(4)
+
+SetAccelX(X, ControllerID)
+SetAccelY(Y, ControllerID)
+SetAccelZ(Z, ControllerID)
+-- Sets the corresponding accelerometer values for the given Wiimote
+-- X/Y/Z is an integer between 0 and 1023 (inclusive)
+
+GetAccel(ControllerID)
+-- Returns the accelerometer data for the specified controller if the current input poll corresponds to that controller, otherwise it returns nil
+-- e.g. x, y, z = GetAccel(ControllerID)
+
+SetNunchuckAccelX(X, ControllerID)
+SetNunchuckAccelY(Y, ControllerID)
+SetNunchuckAccelZ(Z, ControllerID)
+-- Sets the corresponding accelerometer values for the nuncheck extension of the provided Wiimote (if present)
+-- X/Y/Z is an integer between 0 and 1023 (inclusive) where 512 represents no acceleration
+
+GetNunchuckAccel(ControllerID)
+-- Returns the accelerometer data for the nunchuck extension of the provided Wiimote (if present)
+
+SetMainStickX(X, ControllerID)
+SetMainStickY(Y, ControllerID)
+-- Sets the X/Y coordinate for the main control stick
+-- For Wiimotes, this sets the nunchuck stick (if present)
+-- X/Y is an integer between 0 and 255 (inclusive)
+
+SetCStickX(X, ControllerID)
+SetCStickY(Y, ControllerID)
+-- Sets the X/Y coordinate for the secondary control stick
+-- X/Y is an integer between 0 and 255 (inclusive)
+
+SetIRBytes(ControllerID, bytes, ...)
+-- Input as many bytes as you want to override
+-- NOTE: ControllerID is NOT optional for this function
+-- If you attempt to write more bytes than the controller sends, it will write the maximum amount of bytes possible
+-- e.g. SetIRBytes(4, 0xFF, 0xA0)
+-- Returns the number of bytes written (for one controller)
 ```
 
 Implemented callbacks:

--- a/Source/Core/Core/HW/SI_DeviceGCController.cpp
+++ b/Source/Core/Core/HW/SI_DeviceGCController.cpp
@@ -123,7 +123,7 @@ void CSIDevice_GCController::HandleMoviePadStatus(GCPadStatus* PadStatus)
 
 	Movie::CallTAStudioManip(PadStatus); // TAStudio - Added by THC98
 
-	Lua::UpdateScripts(PadStatus);
+	Lua::UpdateScripts(PadStatus, ISIDevice::m_iDeviceNumber);
 
 	Movie::SetPolledDevice();
 	if (NetPlay_GetInput(ISIDevice::m_iDeviceNumber, PadStatus))

--- a/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.cpp
@@ -23,6 +23,7 @@
 #include "Core/HW/WiimoteEmu/Attachment/Nunchuk.h"
 #include "Core/HW/WiimoteEmu/Attachment/Turntable.h"
 #include "Core/HW/WiimoteReal/WiimoteReal.h"
+#include "Core/LUA/Lua.h"
 
 namespace
 {
@@ -746,6 +747,10 @@ void Wiimote::Update()
 
 		Movie::CallWiiInputManip(data, rptf, m_index, m_extension->active_extension, m_ext_key);
 	}
+
+	// take precedence over TAS input (however, it does not change inputs when a movie is playing)
+	Lua::UpdateScripts(data, rptf, m_index, m_extension->active_extension, m_ext_key);
+
 	if (NetPlay::IsNetPlayRunning())
 	{
 		NetPlay_GetWiimoteData(m_index, data, rptf.size);

--- a/Source/Core/Core/LUA/Lua.cpp
+++ b/Source/Core/Core/LUA/Lua.cpp
@@ -41,6 +41,7 @@
 #include "InputCommon/GCPadStatus.h"
 #include "VideoCommon/Statistics.h"
 #include "VideoCommon/VideoConfig.h"
+#include "VideoCommon/RenderBase.h"
 #include "Core/Host.h"
 
 //#include "DolphinWX/Main.h"
@@ -545,6 +546,23 @@ int SetInfoDisplay(lua_State* L)
 	int argc = lua_gettop(L);	
 	SConfig::GetInstance().m_ShowRAMDisplay = !SConfig::GetInstance().m_ShowRAMDisplay;	
 	SConfig::GetInstance().SaveSettings();
+	return 0;
+}
+
+int RenderText(lua_State* L)
+{
+	int argc = lua_gettop(L);
+	if (argc < 5)
+		return 0;
+
+	const char *text = lua_tostring(L, 1);
+	int left = lua_tointeger(L, 2);
+	int top = lua_tointeger(L, 3);
+	u32 color = (u32)lua_tointeger(L, 4) + 0xFF000000; // ??RRGGBB
+	int size = lua_tointeger(L, 5);
+
+	Renderer::DrawLuaText(text, left, top, color, size);
+
 	return 0;
 }
 
@@ -1395,6 +1413,7 @@ namespace Lua
 		lua_register(luaState, "SetScreenText", SetScreenText);
 		lua_register(luaState, "PauseEmulation", PauseEmulation);
 		lua_register(luaState, "SetInfoDisplay", SetInfoDisplay); 
+		lua_register(luaState, "RenderText", RenderText); // Xander: directly control text rendering
 
 		// added by luckytyphlosion
 		lua_register(luaState, "SetFrameAndAudioDump", SetFrameAndAudioDump);

--- a/Source/Core/Core/LUA/Lua.cpp
+++ b/Source/Core/Core/LUA/Lua.cpp
@@ -47,6 +47,8 @@
 //#include "DolphinWX/Frame.h"
 
 static const int ANY_CONTROLLER = -1;
+static const int NUNCHUK = 1;
+static const int CLASSIC = 2;
 
 //Lua Functions (C)
 int ReadValue8(lua_State* L)
@@ -309,6 +311,16 @@ int GetScriptsDir(lua_State* L)
 	return 1;
 }
 
+int GetWiimoteKey(lua_State* L)
+{
+	int controller;
+	char *key = Lua::iGetWiimoteKey(&controller);
+	lua_pushinteger(L, controller);
+	lua_pushstring(L, key);
+	free(key);
+	return 2;
+}
+
 int PressButton(lua_State* L)
 {
 	if (Movie::IsPlayingInput())
@@ -351,86 +363,78 @@ int ReleaseButton(lua_State* L)
 	return 0; // number of return values
 }
 
-int SetMainStickX(lua_State* L)
+static int GenericSet(lua_State *L, void (*f)(int, int))
 {
 	if (Movie::IsPlayingInput())
 		return 0;
-	
+
 	int argc = lua_gettop(L);
 
 	if (argc < 1)
 		return 0;
 
-	int xPos = lua_tointeger(L, 1);
+	int val = lua_tointeger(L, 1);
 	int controller = ANY_CONTROLLER;
 
 	if (argc > 1)
 		controller = lua_tointeger(L, 2);
 
-	Lua::iSetMainStickX(xPos, controller);
+	f(val, controller);
 
 	return 0;
 }
+
+int SetMainStickX(lua_State* L)
+{
+	return GenericSet(L, Lua::iSetMainStickX);
+}
 int SetMainStickY(lua_State* L)
 {
-	if (Movie::IsPlayingInput())
-		return 0;
-	
-	int argc = lua_gettop(L);
-
-	if (argc < 1)
-		return 0;
-
-	int yPos = lua_tointeger(L, 1);
-	int controller = ANY_CONTROLLER;
-
-	if (argc > 1)
-		controller = lua_tointeger(L, 2);
-
-	Lua::iSetMainStickY(yPos, controller);
-
-	return 0;
+	return GenericSet(L, Lua::iSetMainStickY);
 }
 
 int SetCStickX(lua_State* L)
 {
-	if (Movie::IsPlayingInput())
-		return 0;
-	
-	int argc = lua_gettop(L);
-
-	if (argc < 1)
-		return 0;
-
-	int xPos = lua_tointeger(L, 1);
-	int controller = ANY_CONTROLLER;
-
-	if (argc > 1)
-		controller = lua_tointeger(L, 2);
-
-	Lua::iSetCStickX(xPos, controller);
-
-	return 0;
+	return GenericSet(L, Lua::iSetCStickX);
 }
 int SetCStickY(lua_State* L)
 {
-	if (Movie::IsPlayingInput())
-		return 0;
-	
-	int argc = lua_gettop(L);
+	return GenericSet(L, Lua::iSetCStickY);
+}
 
-	if (argc < 1)
-		return 0;
+int SetIRX(lua_State *L)
+{
+	return GenericSet(L, Lua::iSetIRX);
+}
+int SetIRY(lua_State *L)
+{
+	return GenericSet(L, Lua::iSetIRY);
+}
 
-	int yPos = lua_tointeger(L, 1);
-	int controller = ANY_CONTROLLER;
+int SetAccelX(lua_State *L)
+{
+	return GenericSet(L, Lua::iSetAccelX);
+}
+int SetAccelY(lua_State *L)
+{
+	return GenericSet(L, Lua::iSetAccelY);
+}
+int SetAccelZ(lua_State *L)
+{
+	return GenericSet(L, Lua::iSetAccelZ);
+}
 
-	if (argc > 1)
-		controller = lua_tointeger(L, 2);
-
-	Lua::iSetCStickY(yPos, controller);
-
-	return 0;
+int SetNunchukAccelX(lua_State *L)
+{
+	return GenericSet(L, Lua::iSetNunchukAccelX);
+}
+int SetNunchukAccelY(lua_State *L)
+{
+	return GenericSet(L, Lua::iSetNunchukAccelY);
+}
+int SetNunchukAccelZ(lua_State *L)
+{
+	return GenericSet(L, Lua::iSetNunchukAccelZ);
 }
 
 int SaveState(lua_State* L)
@@ -608,8 +612,13 @@ namespace Lua
 	static std::list<LuaScript> scriptList;
 	static int currScriptID;
 
-	static GCPadStatus PadLocal;
     static int currentControllerID;
+    static bool UpdateGCC;
+	static GCPadStatus PadLocal;
+    static u8 *WiimoteData;
+    static int WiimoteExt;
+    static WiimoteEmu::ReportFeatures WiimoteRptf;
+    static const wiimote_key *WiimoteKey;
 
 	const int m_gc_pad_buttons_bitmask[12] = {
 		PAD_BUTTON_DOWN, PAD_BUTTON_UP, PAD_BUTTON_LEFT, PAD_BUTTON_RIGHT, PAD_BUTTON_A, PAD_BUTTON_B,
@@ -633,56 +642,238 @@ namespace Lua
 
 		if (!strcmp(button, "A"))
 		{
-			PadLocal.button |= m_gc_pad_buttons_bitmask[4];
-			PadLocal.analogA = 0xFF;
+			if (UpdateGCC)
+			{
+			    PadLocal.button |= m_gc_pad_buttons_bitmask[4];
+			    PadLocal.analogA = 0xFF;
+			}
+		    else if (WiimoteRptf.ext && WiimoteExt == CLASSIC) // See TASInputDlg::GetValues for data setup
+			{
+
+			}
+			else
+			{
+			    ((wm_buttons *)(WiimoteData + WiimoteRptf.core))->hex |= WiimoteEmu::Wiimote::BUTTON_A;
+			}
 		}
 		else if (!strcmp(button, "B"))
 		{
-			PadLocal.button |= m_gc_pad_buttons_bitmask[5];
-			PadLocal.analogB = 0xFF;
+			if (UpdateGCC)
+			{
+			    PadLocal.button |= m_gc_pad_buttons_bitmask[5];
+			    PadLocal.analogB = 0xFF;
+			}
+		    else if (WiimoteRptf.ext && WiimoteExt == CLASSIC)
+			{
+
+			}
+			else
+			{
+			    ((wm_buttons *)(WiimoteData + WiimoteRptf.core))->hex |= WiimoteEmu::Wiimote::BUTTON_B;
+			}
 		}
 		else if (!strcmp(button, "X"))
 		{
-			PadLocal.button |= m_gc_pad_buttons_bitmask[6];
+			if (UpdateGCC)
+			{
+			    PadLocal.button |= m_gc_pad_buttons_bitmask[6];
+			}
+		    else if (WiimoteRptf.ext && WiimoteExt == CLASSIC)
+			{
+
+			}
 		}
 		else if (!strcmp(button, "Y"))
 		{
-			PadLocal.button |= m_gc_pad_buttons_bitmask[7];
+		    if (UpdateGCC)
+		    {
+				PadLocal.button |= m_gc_pad_buttons_bitmask[7];
+			}
+		    else if (WiimoteRptf.ext && WiimoteExt == CLASSIC)
+			{
+
+			}
 		}
 		else if (!strcmp(button, "Z"))
 		{
-			PadLocal.button |= m_gc_pad_buttons_bitmask[8];
+		    if (UpdateGCC)
+		    {
+				PadLocal.button |= m_gc_pad_buttons_bitmask[8];
+			}
+		    else if (WiimoteRptf.ext && WiimoteExt == NUNCHUK)
+			{
+			    wm_nc *nunchuk = (wm_nc *)(WiimoteData + WiimoteRptf.ext);
+			    WiimoteDecrypt(WiimoteKey, (u8 *)nunchuk, 0, sizeof(wm_nc));
+			    nunchuk->bt.hex &= ~WiimoteEmu::Nunchuk::BUTTON_Z;
+			    WiimoteEncrypt(WiimoteKey, (u8 *)nunchuk, 0, sizeof(wm_nc));
+			}
 		}
 		else if (!strcmp(button, "L"))
 		{
-			PadLocal.triggerLeft = 255;
-			PadLocal.button |= m_gc_pad_buttons_bitmask[9];
+			if (UpdateGCC)
+		    {
+			    PadLocal.triggerLeft = 255;
+			    PadLocal.button |= m_gc_pad_buttons_bitmask[9];
+			}
+		    else if (WiimoteRptf.ext && WiimoteExt == NUNCHUK)
+		    {
+
+		    } 
 		}
+	    else if (!strcmp(button, "ZL"))
+	    {
+		    if (WiimoteRptf.ext && WiimoteExt == CLASSIC)
+		    {
+
+		    }
+	    }
 		else if (!strcmp(button, "R"))
 		{
-			PadLocal.triggerRight = 255;
-			PadLocal.button |= m_gc_pad_buttons_bitmask[10];
+		    if (UpdateGCC)
+		    {
+				PadLocal.triggerRight = 255;
+				PadLocal.button |= m_gc_pad_buttons_bitmask[10];
+		    }
+		    else if (WiimoteRptf.ext && WiimoteExt == NUNCHUK)
+		    {
+
+		    } 
 		}
+	    else if (!strcmp(button, "ZR"))
+	    {
+		    if (WiimoteRptf.ext && WiimoteExt == CLASSIC)
+		    {
+
+		    }
+	    }
 		else if (!strcmp(button, "Start"))
 		{
-			PadLocal.button |= m_gc_pad_buttons_bitmask[11];
+		    if (UpdateGCC)
+				PadLocal.button |= m_gc_pad_buttons_bitmask[11];
 		}
-		else if (!strcmp(button, "D-Up"))
+	    else if (!strcmp(button, "D-Up") || !strcmp(button, "UP"))
 		{
-			PadLocal.button |= m_gc_pad_buttons_bitmask[1];
+			if (UpdateGCC)
+			{
+				PadLocal.button |= m_gc_pad_buttons_bitmask[1];
+			}
+		    else if (WiimoteRptf.ext && WiimoteExt == CLASSIC)
+			{
+
+			}
+			else
+		    {
+			    ((wm_buttons *)(WiimoteData + WiimoteRptf.core))->hex |= WiimoteEmu::Wiimote::PAD_UP;
+			}
 		}
-		else if (!strcmp(button, "D-Down"))
+	    else if (!strcmp(button, "D-Down") || !strcmp(button, "DOWN"))
 		{
-			PadLocal.button |= m_gc_pad_buttons_bitmask[0];
+		    if (UpdateGCC)
+		    {
+			    PadLocal.button |= m_gc_pad_buttons_bitmask[0];
+		    }
+		    else if (WiimoteRptf.ext && WiimoteExt == CLASSIC)
+		    {
+
+		    }
+		    else
+		    {
+			    ((wm_buttons *)(WiimoteData + WiimoteRptf.core))->hex |= WiimoteEmu::Wiimote::PAD_DOWN;
+		    }
 		}
-		else if (!strcmp(button, "D-Left"))
+	    else if (!strcmp(button, "D-Left") || !strcmp(button, "LEFT"))
 		{
-			PadLocal.button |= m_gc_pad_buttons_bitmask[2];
+			if (UpdateGCC)
+			{
+			    PadLocal.button |= m_gc_pad_buttons_bitmask[2];
+		    }
+		    else if (WiimoteRptf.ext && WiimoteExt == CLASSIC)
+		    {
+
+		    }
+		    else
+		    {
+			    ((wm_buttons *)(WiimoteData + WiimoteRptf.core))->hex |= WiimoteEmu::Wiimote::PAD_LEFT;
+		    }
 		}
-		else if (!strcmp(button, "D-Right"))
+	    else if (!strcmp(button, "D-Right") || !strcmp(button, "RIGHT"))
 		{
-			PadLocal.button |= m_gc_pad_buttons_bitmask[3];
-		}		
+			if (UpdateGCC)
+			{
+			    PadLocal.button |= m_gc_pad_buttons_bitmask[3];
+		    }
+		    else if (WiimoteRptf.ext && WiimoteExt == CLASSIC)
+		    {
+
+		    }
+		    else
+		    {
+			    ((wm_buttons *)(WiimoteData + WiimoteRptf.core))->hex |= WiimoteEmu::Wiimote::PAD_RIGHT;
+		    }
+		}
+	    else if (!strcmp(button, "C"))
+	    {
+		    if (WiimoteRptf.ext && WiimoteExt == NUNCHUK)
+		    {
+			    wm_nc *nunchuk = (wm_nc *)(WiimoteData + WiimoteRptf.ext);
+			    WiimoteDecrypt(WiimoteKey, (u8 *)nunchuk, 0, sizeof(wm_nc));
+			    nunchuk->bt.hex &= ~WiimoteEmu::Nunchuk::BUTTON_C;
+			    WiimoteEncrypt(WiimoteKey, (u8 *)nunchuk, 0, sizeof(wm_nc));
+		    }
+	    }
+	    else if (!strcmp(button, "Home") || !strcmp(button, "HOME"))
+	    {
+		    if (WiimoteRptf.ext && WiimoteExt == CLASSIC)
+		    {
+
+		    }
+		    else
+		    {
+			    ((wm_buttons *)(WiimoteData + WiimoteRptf.core))->hex |= WiimoteEmu::Wiimote::BUTTON_HOME;
+		    }
+	    }
+	    else if (!strcmp(button, "+"))
+	    {
+		    if (WiimoteRptf.ext && WiimoteExt == CLASSIC)
+		    {
+
+		    }
+		    else
+		    {
+			    ((wm_buttons *)(WiimoteData + WiimoteRptf.core))->hex |= WiimoteEmu::Wiimote::BUTTON_PLUS;
+		    }
+	    }
+	    else if (!strcmp(button, "-"))
+	    {
+		    if (WiimoteRptf.ext && WiimoteExt == CLASSIC)
+		    {
+
+		    }
+		    else
+		    {
+			    ((wm_buttons *)(WiimoteData + WiimoteRptf.core))->hex |= WiimoteEmu::Wiimote::BUTTON_MINUS;
+		    }
+	    }
+	    else if (!strcmp(button, "1"))
+	    {
+		    if (WiimoteRptf.ext && WiimoteExt == CLASSIC)
+		    {
+		    }
+		    else
+		    {
+			    ((wm_buttons *)(WiimoteData + WiimoteRptf.core))->hex |= WiimoteEmu::Wiimote::BUTTON_ONE;
+		    }
+	    }
+	    else if (!strcmp(button, "2"))
+	    {
+		    if (WiimoteRptf.ext && WiimoteExt == CLASSIC)
+		    {
+		    }
+		    else
+		    {
+			    ((wm_buttons *)(WiimoteData + WiimoteRptf.core))->hex |= WiimoteEmu::Wiimote::BUTTON_TWO;
+		    }
+	    }
 	}
     void iReleaseButton(const char *button, int controllerID)
     {
@@ -693,6 +884,7 @@ namespace Lua
 		{
 			PadLocal.button &= ~m_gc_pad_buttons_bitmask[4];
 			PadLocal.analogA = 0x00;
+
 		}
 		else if (!strcmp(button, "B"))
 		{
@@ -701,7 +893,7 @@ namespace Lua
 		}
 		else if (!strcmp(button, "X"))
 		{
-			PadLocal.button &= ~m_gc_pad_buttons_bitmask[6];
+		    PadLocal.button &= ~m_gc_pad_buttons_bitmask[6];
 		}
 		else if (!strcmp(button, "Y"))
 		{
@@ -713,33 +905,33 @@ namespace Lua
 		}
 		else if (!strcmp(button, "L"))
 		{
-			PadLocal.triggerLeft = 0;
+		    PadLocal.triggerLeft = 0;
 			PadLocal.button &= ~m_gc_pad_buttons_bitmask[9];
 		}
 		else if (!strcmp(button, "R"))
 		{
-			PadLocal.triggerRight = 0;
+		    PadLocal.triggerRight = 0;
 			PadLocal.button &= ~m_gc_pad_buttons_bitmask[10];
 		}
 		else if (!strcmp(button, "Start"))
 		{
 			PadLocal.button &= ~m_gc_pad_buttons_bitmask[11];
 		}
-		else if (!strcmp(button, "D-Up"))
+	    else if (!strcmp(button, "D-Up"))
 		{
 			PadLocal.button &= ~m_gc_pad_buttons_bitmask[1];
 		}
-		else if (!strcmp(button, "D-Down"))
+	    else if (!strcmp(button, "D-Down"))
 		{
-			PadLocal.button &= ~m_gc_pad_buttons_bitmask[0];
+		    PadLocal.button &= ~m_gc_pad_buttons_bitmask[0];
 		}
-		else if (!strcmp(button, "D-Left"))
+	    else if (!strcmp(button, "D-Left"))
 		{
-			PadLocal.button &= ~m_gc_pad_buttons_bitmask[2];
+		    PadLocal.button &= ~m_gc_pad_buttons_bitmask[2];
 		}
-		else if (!strcmp(button, "D-Right"))
+	    else if (!strcmp(button, "D-Right"))
 		{
-			PadLocal.button &= ~m_gc_pad_buttons_bitmask[3];
+		    PadLocal.button &= ~m_gc_pad_buttons_bitmask[3];
 		}
 	}
 
@@ -792,23 +984,251 @@ namespace Lua
 
 	void iSetMainStickX(int xVal, int controllerID)
     {
-	    if (controllerID == currentControllerID || controllerID == ANY_CONTROLLER)
-			PadLocal.stickX = xVal;
+	    if (controllerID != currentControllerID && controllerID != ANY_CONTROLLER)
+		    return;
+
+		if (UpdateGCC)
+		{
+		    PadLocal.stickX = xVal;
+		}
+		else if (WiimoteRptf.ext && WiimoteExt == NUNCHUK)
+	    {
+		    wm_nc *nunchuk = (wm_nc *)(WiimoteData + WiimoteRptf.ext);
+		    WiimoteDecrypt(WiimoteKey, (u8 *)nunchuk, 0, sizeof(wm_nc));
+		    nunchuk->jx = xVal;
+		    WiimoteEncrypt(WiimoteKey, (u8 *)nunchuk, 0, sizeof(wm_nc));
+		}
+	    else if (WiimoteRptf.ext && WiimoteExt == CLASSIC)
+		{
+			// JL x
+		}
 	}
     void iSetMainStickY(int yVal, int controllerID)
 	{
-	    if (controllerID == currentControllerID || controllerID == ANY_CONTROLLER)
+	    if (controllerID != currentControllerID && controllerID != ANY_CONTROLLER)
+		    return;
+
+	    if (UpdateGCC)
+	    {
 			PadLocal.stickY = yVal;
+	    }
+	    else if (WiimoteRptf.ext && WiimoteExt == NUNCHUK)
+	    {
+		    wm_nc *nunchuk = (wm_nc *)(WiimoteData + WiimoteRptf.ext);
+		    WiimoteDecrypt(WiimoteKey, (u8 *)nunchuk, 0, sizeof(wm_nc));
+		    nunchuk->jy = yVal;
+		    WiimoteEncrypt(WiimoteKey, (u8 *)nunchuk, 0, sizeof(wm_nc));
+	    }
+	    else if (WiimoteRptf.ext && WiimoteExt == CLASSIC)
+	    {
+		    // JL y
+	    }
 	}
     void iSetCStickX(int xVal, int controllerID)
 	{
-	    if (controllerID == currentControllerID || controllerID == ANY_CONTROLLER)
+	    if (controllerID != currentControllerID && controllerID != ANY_CONTROLLER)
+		    return;
+
+	    if (UpdateGCC)
+	    {
 			PadLocal.substickX = xVal;
+		}
+	    else if (WiimoteRptf.ext && WiimoteExt == CLASSIC)
+		{
+			// JR x
+		}
 	}
     void iSetCStickY(int yVal, int controllerID)
 	{
-	    if (controllerID == currentControllerID || controllerID == ANY_CONTROLLER)
+	    if (controllerID != currentControllerID && controllerID != ANY_CONTROLLER)
+		    return;
+
+	    if (UpdateGCC)
+	    {
 			PadLocal.substickY = yVal;
+	    }
+	    else if (WiimoteRptf.ext && WiimoteExt == CLASSIC)
+	    {
+		    // JR y
+	    }
+	}
+    static void SetIR(int xVal, int yVal, int controllerID)
+	{
+	    if (controllerID != currentControllerID && controllerID != ANY_CONTROLLER)
+		    return;
+
+	    u16 x[4];
+	    x[0] = xVal;
+	    x[1] = x[0] + 100;
+	    x[2] = x[0] - 10;
+	    x[3] = x[1] + 10;
+	    u16 y = yVal;
+
+	    if ((WiimoteRptf.ext ? WiimoteRptf.ext : WiimoteRptf.size) - WiimoteRptf.ir == 10)
+	    {
+		    memset(WiimoteData + WiimoteRptf.ir, 0xFF, sizeof(wm_ir_basic) * 2);
+		    wm_ir_basic *ir_data = (wm_ir_basic *)(WiimoteData + WiimoteRptf.ir);
+		    for (unsigned int i = 0; i < 2; ++i)
+		    {
+			    if (x[i * 2] < 1024 && y < 768)
+			    {
+				    ir_data[i].x1 = static_cast<u8>(x[i * 2]);
+				    ir_data[i].x1hi = x[i * 2] >> 8;
+
+				    ir_data[i].y1 = static_cast<u8>(y);
+				    ir_data[i].y1hi = y >> 8;
+			    }
+			    if (x[i * 2 + 1] < 1024 && y < 768)
+			    {
+				    ir_data[i].x2 = static_cast<u8>(x[i * 2 + 1]);
+				    ir_data[i].x2hi = x[i * 2 + 1] >> 8;
+
+				    ir_data[i].y2 = static_cast<u8>(y);
+				    ir_data[i].y2hi = y >> 8;
+			    }
+		    }
+		}
+		else // assumes reporting mode 3 (not 5)
+		{
+			memset(WiimoteData + WiimoteRptf.ir, 0xFF, sizeof(wm_ir_extended) * 4);
+			wm_ir_extended *const ir_data = (wm_ir_extended *)(WiimoteData + WiimoteRptf.ir);
+			for (unsigned int i = 0; i < 4; ++i)
+			{
+			    if (x[i] < 1024 && y < 768)
+			    {
+				    ir_data[i].x = static_cast<u8>(x[i]);
+				    ir_data[i].xhi = x[i] >> 8;
+
+				    ir_data[i].y = static_cast<u8>(y);
+					ir_data[i].yhi = y >> 8;
+
+				    ir_data[i].size = 10;
+			    }
+		    }
+		}
+	   
+	}
+    void iSetIRX(int xVal, int controllerID)
+    {
+	    if (!UpdateGCC && WiimoteRptf.ir)
+	    {
+		    u8 *irdata = (WiimoteData + WiimoteRptf.ir);
+		    int y = irdata[1] + ((irdata[2] & 0xC0) << 2);
+		    SetIR(xVal, y, controllerID);
+	    }
+    }
+    void iSetIRY(int yVal, int controllerID)
+	{
+	    if (!UpdateGCC && WiimoteRptf.ir)
+		{
+		    u8 *irdata = (WiimoteData + WiimoteRptf.ir);
+		    int x = irdata[0] + ((irdata[2] & 0x30) << 4); // read first x coord
+		    SetIR(x, yVal, controllerID);
+		}
+	}
+    void iSetAccelX(int xVal, int controllerID)
+    {
+	    if (UpdateGCC || (controllerID != currentControllerID && controllerID != ANY_CONTROLLER))
+		    return;
+
+	    wm_accel *dt = (wm_accel *)(WiimoteData + WiimoteRptf.accel);
+	    wm_buttons *but = (wm_buttons *)(WiimoteData + WiimoteRptf.core);
+	    dt->x = xVal >> 2;
+	    but->acc_x_lsb = xVal & 0x3;
+    }
+    void iSetAccelY(int yVal, int controllerID)
+    {
+	    if (UpdateGCC || (controllerID != currentControllerID && controllerID != ANY_CONTROLLER))
+		    return;
+
+	    wm_accel *dt = (wm_accel *)(WiimoteData + WiimoteRptf.accel);
+	    wm_buttons *but = (wm_buttons *)(WiimoteData + WiimoteRptf.core);
+	    dt->y = yVal >> 2;
+	    but->acc_y_lsb = yVal >> 1 & 0x1;
+    }
+    void iSetAccelZ(int zVal, int controllerID)
+    {
+	    if (UpdateGCC || (controllerID != currentControllerID && controllerID != ANY_CONTROLLER))
+		    return;
+
+	    wm_accel *dt = (wm_accel *)(WiimoteData + WiimoteRptf.accel);
+	    wm_buttons *but = (wm_buttons *)(WiimoteData + WiimoteRptf.core);
+	    dt->z = zVal >> 2;
+	    but->acc_z_lsb = zVal >> 1 & 0x1;
+    }
+    void iSetNunchukAccelX(int xVal, int controllerID)
+    {
+	    if (UpdateGCC || (controllerID != currentControllerID && controllerID != ANY_CONTROLLER))
+		    return;
+
+	    if (WiimoteRptf.ext && WiimoteExt == NUNCHUK)
+	    {
+		    wm_nc *nunchuk = (wm_nc *)(WiimoteData + WiimoteRptf.ext);
+		    WiimoteDecrypt(WiimoteKey, (u8 *)nunchuk, 0, sizeof(wm_nc));
+		    nunchuk->ax = xVal >> 2;
+		    nunchuk->bt.acc_x_lsb = xVal & 0x3;
+		    WiimoteEncrypt(WiimoteKey, (u8 *)nunchuk, 0, sizeof(wm_nc));
+	    }
+    }
+    void iSetNunchukAccelY(int yVal, int controllerID)
+    {
+	    if (UpdateGCC || (controllerID != currentControllerID && controllerID != ANY_CONTROLLER))
+		    return;
+
+	    if (WiimoteRptf.ext && WiimoteExt == NUNCHUK)
+	    {
+		    wm_nc *nunchuk = (wm_nc *)(WiimoteData + WiimoteRptf.ext);
+		    WiimoteDecrypt(WiimoteKey, (u8 *)nunchuk, 0, sizeof(wm_nc));
+		    nunchuk->ay = yVal >> 2;
+		    nunchuk->bt.acc_y_lsb = yVal & 0x3;
+		    WiimoteEncrypt(WiimoteKey, (u8 *)nunchuk, 0, sizeof(wm_nc));
+	    }
+    }
+    void iSetNunchukAccelZ(int zVal, int controllerID)
+    {
+	    if (UpdateGCC || (controllerID != currentControllerID && controllerID != ANY_CONTROLLER))
+		    return;
+
+		if (WiimoteRptf.ext && WiimoteExt == NUNCHUK)
+		{
+		    wm_nc *nunchuk = (wm_nc *)(WiimoteData + WiimoteRptf.ext);
+		    WiimoteDecrypt(WiimoteKey, (u8 *)nunchuk, 0, sizeof(wm_nc));
+		    nunchuk->az = zVal >> 2;
+		    nunchuk->bt.acc_z_lsb = zVal & 0x3;
+		    WiimoteEncrypt(WiimoteKey, (u8 *)nunchuk, 0, sizeof(wm_nc));
+		}
+    }
+	char *iGetWiimoteKey(int *controllerID)
+	{	
+		*controllerID = currentControllerID;
+		char *key = (char *)malloc(48 * sizeof(char));
+	    key[0] = 0; // empty string on gcc update calls
+	    if (!UpdateGCC)
+		{
+		    sprintf(key, "%02X %02X %02X %02X %02X %02X %02X %02X ", WiimoteKey->ft[0], WiimoteKey->ft[1],
+		            WiimoteKey->ft[2], WiimoteKey->ft[3], WiimoteKey->ft[4], WiimoteKey->ft[5], WiimoteKey->ft[6],
+		            WiimoteKey->ft[7]);
+		    sprintf(key + 24, "%02X %02X %02X %02X %02X %02X %02X %02X", WiimoteKey->sb[0], WiimoteKey->sb[1],
+		            WiimoteKey->sb[2], WiimoteKey->sb[3], WiimoteKey->sb[4], WiimoteKey->sb[5], WiimoteKey->sb[6],
+		            WiimoteKey->sb[7]);
+		}
+	    return key;
+	}
+	int GetIR(lua_State *L) {
+	    int x = -1;
+	    int y = -1;
+	    int controller = ANY_CONTROLLER;
+	    if (lua_gettop(L) > 0)
+		    controller = lua_tointeger(L, 1);
+		if (!UpdateGCC && (controller == currentControllerID || controller == ANY_CONTROLLER))
+		{
+		    u8 *irdata = WiimoteData + WiimoteRptf.ir;
+		    x = irdata[0] + ((irdata[2] & 0x30) << 4); // read first x coord
+		    y = irdata[1] + ((irdata[2] & 0xC0) << 2);
+		}
+	    lua_pushinteger(L, x);
+	    lua_pushinteger(L, y);
+		return 2;
 	}
 	void iSaveState(bool toSlot, int slotID, std::string fileName)
 	{
@@ -905,7 +1325,7 @@ namespace Lua
 		lua_register(luaState, "WriteValueString", WriteValueString);
 
 		lua_register(luaState, "GetGameID", GetGameID);
-		lua_register(luaState, "GetScriptsDir", GetScriptsDir);
+	    lua_register(luaState, "GetScriptsDir", GetScriptsDir);
 
 		lua_register(luaState, "PressButton", PressButton);
 		lua_register(luaState, "ReleaseButton", ReleaseButton);
@@ -913,6 +1333,17 @@ namespace Lua
 		lua_register(luaState, "SetMainStickY", SetMainStickY);
 		lua_register(luaState, "SetCStickX", SetCStickX);
 		lua_register(luaState, "SetCStickY", SetCStickY);
+
+	    lua_register(luaState, "GetWiimoteKey", GetWiimoteKey); // Xander: wiimote + extension controls
+	    lua_register(luaState, "SetIRX", SetIRX);
+	    lua_register(luaState, "SetIRY", SetIRY);
+	    lua_register(luaState, "GetIR", Lua::GetIR);
+	    lua_register(luaState, "SetAccelX", SetAccelX);
+	    lua_register(luaState, "SetAccelY", SetAccelY);
+	    lua_register(luaState, "SetAccelZ", SetAccelZ);
+	    lua_register(luaState, "SetNunchukAccelX", SetNunchukAccelX);
+	    lua_register(luaState, "SetNunchukAccelY", SetNunchukAccelY);
+	    lua_register(luaState, "SetNunchukAccelZ", SetNunchukAccelZ);
 
 		lua_register(luaState, "SaveState", SaveState);
 		lua_register(luaState, "LoadState", LoadState);
@@ -923,7 +1354,7 @@ namespace Lua
 		
 		lua_register(luaState, "SetScreenText", SetScreenText);
 		lua_register(luaState, "PauseEmulation", PauseEmulation);
-		lua_register(luaState, "SetInfoDisplay", SetInfoDisplay);
+		lua_register(luaState, "SetInfoDisplay", SetInfoDisplay); 
 
 		// added by luckytyphlosion
 		lua_register(luaState, "SetFrameAndAudioDump", SetFrameAndAudioDump);
@@ -1023,16 +1454,26 @@ namespace Lua
 		return false;
 	}
 
-
-	//Called every input frame (60 times per second in TP)
-	void UpdateScripts(GCPadStatus* PadStatus, int controllerID)
+	//Called every time a controller is updated (same as fps if there is only 1 gcc)
+    static void UpdateScripts(int controllerID, GCPadStatus *PadStatus, u8 *data, WiimoteEmu::ReportFeatures *rptf, int ext, const wiimote_key *key)
 	{
 		if (!Core::IsRunningAndStarted())
 			return;
 
-		//Update Local Pad
-		PadLocal = *PadStatus;
+		//Update stored copies
 	    currentControllerID = controllerID;
+	    UpdateGCC = data == nullptr;
+	    if (UpdateGCC)
+	    {
+		    PadLocal = *PadStatus;
+	    }
+	    else
+	    {
+		    WiimoteData = data;
+		    WiimoteExt = ext;
+		    WiimoteRptf = *rptf;
+		    WiimoteKey = key;
+	    }
 
 		//Iterate through all the loaded LUA Scripts
 		int n = 0;
@@ -1174,8 +1615,19 @@ namespace Lua
 			++n;
 		}
 
-		//Send changed Pad back
-		*PadStatus = PadLocal;
+		//Send changed Pad back (if this call was not for a wiimote)
+	    if (UpdateGCC)
+		    *PadStatus = PadLocal;
 	}
 
+	void UpdateScripts(GCPadStatus *PadStatus, int controllerID)
+    {
+	    UpdateScripts(controllerID, PadStatus, nullptr, nullptr, 0, nullptr);
+    }
+
+    // Note: if a classic controller extension is used, pressing buttons will set the buttons of the extension
+    void UpdateScripts(u8 *data, WiimoteEmu::ReportFeatures rptf, int controllerID, int ext, const wiimote_key key)
+    {
+	    UpdateScripts(controllerID + 4, nullptr, data, &rptf, ext, &key);
+    }
 }

--- a/Source/Core/Core/LUA/Lua.h
+++ b/Source/Core/Core/LUA/Lua.h
@@ -9,6 +9,7 @@
 #include <string>
 #include "Common/CommonTypes.h"
 #include "DolphinWX/Main.h"
+#include "Core/HW/WiimoteEmu/WiimoteEmu.h"
 
 #include <lua.hpp>
 #include <lua.h>
@@ -28,12 +29,21 @@ int WriteValueFloat(lua_State *L);
 int WriteValueString(lua_State *L);
 int GetPointerNormal(lua_State *L);
 int GetGameID(lua_State *L);
+int GetWiimoteKey(lua_State *L);
 int PressButton(lua_State *L);
 int ReleaseButton(lua_State *L);
 int SetMainStickX(lua_State *L);
 int SetMainStickY(lua_State *L);
 int SetCStickX(lua_State *L);
 int SetCStickY(lua_State *L);
+int SetIRX(lua_State *L);
+int SetIRY(lua_State *L);
+int SetAccelX(lua_State *L);
+int SetAccelY(lua_State *L);
+int SetAccelZ(lua_State *L);
+int SetNunchukAccelX(lua_State *L);
+int SetNunchukAccelY(lua_State *L);
+int SetNunchukAccelZ(lua_State *L);
 int SaveState(lua_State *L);
 int LoadState(lua_State *L);
 int GetFrameCount(lua_State *L);
@@ -78,6 +88,7 @@ namespace Lua
 	void TerminateScript(std::string fileName);
 	bool IsScriptRunning(std::string fileName);
 	void UpdateScripts(GCPadStatus* PadStatus, int controllerID);
+    void UpdateScripts(u8 *data, WiimoteEmu::ReportFeatures rptf, int controllerID, int ext, const wiimote_key key);
     u32 readPointer(u32 startAddress, u32 offset);
 	u32 normalizePointer(u32 pointer);
     u32 ExecuteMultilevelLoop(lua_State *L);
@@ -89,6 +100,16 @@ namespace Lua
     void iSetMainStickY(int yVal, int controllerID);
     void iSetCStickX(int xVal, int controllerID);
     void iSetCStickY(int yVal, int controllerID);
+    void iSetIRX(int xVal, int controllerID);
+    void iSetIRY(int xVal, int controllerID);
+    void iSetAccelX(int xVal, int controllerID);
+    void iSetAccelY(int yVal, int controllerID);
+    void iSetAccelZ(int zVal, int controllerID);
+    void iSetNunchukAccelX(int xVal, int controllerID);
+    void iSetNunchukAccelY(int yVal, int controllerID);
+    void iSetNunchukAccelZ(int zVal, int controllerID);
+    char *iGetWiimoteKey(int *controllerID);
+    int GetIR(lua_State *L);
 	void iSaveState(bool toSlot, int slotID, std::string fileName);
 	void iLoadState(bool fromSlot, int slotID, std::string fileName);
 	void iCancelCurrentScript();

--- a/Source/Core/Core/LUA/Lua.h
+++ b/Source/Core/Core/LUA/Lua.h
@@ -77,18 +77,18 @@ namespace Lua
 	void LoadScript(std::string fileName);
 	void TerminateScript(std::string fileName);
 	bool IsScriptRunning(std::string fileName);
-	void UpdateScripts(GCPadStatus* PadStatus);
+	void UpdateScripts(GCPadStatus* PadStatus, int controllerID);
     u32 readPointer(u32 startAddress, u32 offset);
 	u32 normalizePointer(u32 pointer);
     u32 ExecuteMultilevelLoop(lua_State *L);
     bool IsInMEMArea(u32 pointer);
 
-	void iPressButton(const char* button);
-	void iReleaseButton(const char* button);
-	void iSetMainStickX(int xVal);
-	void iSetMainStickY(int yVal);
-	void iSetCStickX(int xVal);
-	void iSetCStickY(int yVal);
+	void iPressButton(const char* button, int controllerID);
+    void iReleaseButton(const char *button, int controllerID);
+    void iSetMainStickX(int xVal, int controllerID);
+    void iSetMainStickY(int yVal, int controllerID);
+    void iSetCStickX(int xVal, int controllerID);
+    void iSetCStickY(int yVal, int controllerID);
 	void iSaveState(bool toSlot, int slotID, std::string fileName);
 	void iLoadState(bool fromSlot, int slotID, std::string fileName);
 	void iCancelCurrentScript();

--- a/Source/Core/Core/LUA/Lua.h
+++ b/Source/Core/Core/LUA/Lua.h
@@ -100,6 +100,7 @@ namespace Lua
     void iSetMainStickY(int yVal, int controllerID);
     void iSetCStickX(int xVal, int controllerID);
     void iSetCStickY(int yVal, int controllerID);
+    int iSetIRBytes(int bytes[], int numBytes, int controllerID);
     void iSetIRX(int xVal, int controllerID);
     void iSetIRY(int xVal, int controllerID);
     void iSetAccelX(int xVal, int controllerID);

--- a/Source/Core/DolphinWX/TASInputDlg.cpp
+++ b/Source/Core/DolphinWX/TASInputDlg.cpp
@@ -762,7 +762,7 @@ void TASInputDlg::GetValues(u8 *data, WiimoteEmu::ReportFeatures rptf, int ext, 
 		}
 		else
 		{
-			memset(data, 0xFF, sizeof(wm_ir_extended) * 4);
+			memset(irData, 0xFF, sizeof(wm_ir_extended) * 4);
 			wm_ir_extended* const ir_data = (wm_ir_extended*)irData;
 			for (unsigned int i = 0; i < 4; ++i)
 			{

--- a/Source/Core/VideoBackends/D3D/Render.cpp
+++ b/Source/Core/VideoBackends/D3D/Render.cpp
@@ -283,10 +283,10 @@ Renderer::~Renderer()
 	D3D::Close();
 }
 
-void Renderer::RenderText(const std::string& text, int left, int top, u32 color)
+void Renderer::RenderText(const std::string& text, int left, int top, u32 color, int size)
 {
-	D3D::font.DrawTextScaled((float)(left+1), (float)(top+1), 20.f, 0.0f, color & 0xFF000000, text);
-	D3D::font.DrawTextScaled((float)left, (float)top, 20.f, 0.0f, color, text);
+	D3D::font.DrawTextScaled((float)(left+1), (float)(top+1), 20.f * (float)size / 11.f, 0.0f, color & 0xFF000000, text);
+	D3D::font.DrawTextScaled((float)left, (float)top, 20.f * (float)size / 11.f, 0.0f, color, text);
 }
 
 TargetRectangle Renderer::ConvertEFBRectangle(const EFBRectangle& rc)

--- a/Source/Core/VideoBackends/D3D/Render.h
+++ b/Source/Core/VideoBackends/D3D/Render.h
@@ -34,7 +34,7 @@ public:
 	void ApplyCullDisable();
 	void RestoreCull();
 
-	void RenderText(const std::string& text, int left, int top, u32 color) override;
+	void RenderText(const std::string &text, int left, int top, u32 color, int size = 11) override;
 
 	u32 AccessEFB(EFBAccessType type, u32 x, u32 y, u32 poke_data) override;
 	void PokeEFB(EFBAccessType type, const EfbPokeData* points, size_t num_points) override;

--- a/Source/Core/VideoBackends/D3D12/Render.cpp
+++ b/Source/Core/VideoBackends/D3D12/Render.cpp
@@ -283,10 +283,10 @@ Renderer::~Renderer()
 	TeardownDeviceObjects();
 }
 
-void Renderer::RenderText(const std::string& text, int left, int top, u32 color)
+void Renderer::RenderText(const std::string &text, int left, int top, u32 color, int size)
 {
-	D3D::font.DrawTextScaled(static_cast<float>(left + 1), static_cast<float>(top + 1), 20.f, 0.0f, color & 0xFF000000, text);
-	D3D::font.DrawTextScaled(static_cast<float>(left), static_cast<float>(top), 20.f, 0.0f, color, text);
+	D3D::font.DrawTextScaled(static_cast<float>(left + 1), static_cast<float>(top + 1), 20.f * (float)size / 11.f, 0.0f, color & 0xFF000000, text);
+	D3D::font.DrawTextScaled(static_cast<float>(left), static_cast<float>(top), 20.f * (float)size / 11.f, 0.0f, color, text);
 }
 
 TargetRectangle Renderer::ConvertEFBRectangle(const EFBRectangle& rc)

--- a/Source/Core/VideoBackends/D3D12/Render.h
+++ b/Source/Core/VideoBackends/D3D12/Render.h
@@ -34,7 +34,7 @@ public:
 	void ApplyCullDisable();
 	void RestoreCull();
 
-	void RenderText(const std::string& text, int left, int top, u32 color) override;
+	void RenderText(const std::string &text, int left, int top, u32 color, int size = 11) override;
 
 	u32 AccessEFB(EFBAccessType type, u32 x, u32 y, u32 poke_data) override;
 	void PokeEFB(EFBAccessType type, const EfbPokeData* points, size_t num_points) override;

--- a/Source/Core/VideoBackends/OGL/Render.cpp
+++ b/Source/Core/VideoBackends/OGL/Render.cpp
@@ -716,7 +716,7 @@ void Renderer::Init()
 	OpenGL_CreateAttributelessVAO();
 }
 
-void Renderer::RenderText(const std::string& text, int left, int top, u32 color)
+void Renderer::RenderText(const std::string& text, int left, int top, u32 color, int size)
 {
 	const int nBackbufferWidth = (int)GLInterface->GetBackBufferWidth();
 	const int nBackbufferHeight = (int)GLInterface->GetBackBufferHeight();
@@ -724,7 +724,7 @@ void Renderer::RenderText(const std::string& text, int left, int top, u32 color)
 	s_raster_font->printMultilineText(text,
 		left * 2.0f / (float)nBackbufferWidth - 1,
 		1 - top * 2.0f / (float)nBackbufferHeight,
-		0, nBackbufferWidth, nBackbufferHeight, color);
+		0, nBackbufferWidth * 11 / size, nBackbufferHeight * 11 / size, color);
 }
 
 TargetRectangle Renderer::ConvertEFBRectangle(const EFBRectangle& rc)

--- a/Source/Core/VideoBackends/OGL/Render.h
+++ b/Source/Core/VideoBackends/OGL/Render.h
@@ -82,7 +82,7 @@ public:
 	void SetInterlacingMode() override;
 	void SetViewport() override;
 
-	void RenderText(const std::string& text, int left, int top, u32 color) override;
+	void RenderText(const std::string &text, int left, int top, u32 color, int size = 11) override;
 
 	u32 AccessEFB(EFBAccessType type, u32 x, u32 y, u32 poke_data) override;
 	void PokeEFB(EFBAccessType type, const EfbPokeData* points, size_t num_points) override;

--- a/Source/Core/VideoBackends/Software/SWRenderer.cpp
+++ b/Source/Core/VideoBackends/Software/SWRenderer.cpp
@@ -48,7 +48,7 @@ void SWRenderer::Shutdown()
 	UpdateActiveConfig();
 }
 
-void SWRenderer::RenderText(const std::string& pstr, int left, int top, u32 color)
+void SWRenderer::RenderText(const std::string &pstr, int left, int top, u32 color, int size)
 {
 	SWOGLWindow::s_instance->PrintText(pstr, left, top, color);
 }

--- a/Source/Core/VideoBackends/Software/SWRenderer.h
+++ b/Source/Core/VideoBackends/Software/SWRenderer.h
@@ -24,7 +24,7 @@ public:
 	void SwapColorTexture();
 	void UpdateColorTexture(EfbInterface::yuv422_packed *xfb, u32 fbWidth, u32 fbHeight);
 
-	void RenderText(const std::string& pstr, int left, int top, u32 color) override;
+	void RenderText(const std::string& pstr, int left, int top, u32 color, int size = 11) override;
 	u32 AccessEFB(EFBAccessType type, u32 x, u32 y, u32 poke_data) override;
 	void PokeEFB(EFBAccessType type, const EfbPokeData* points, size_t num_points) override {};
 

--- a/Source/Core/VideoCommon/RenderBase.h
+++ b/Source/Core/VideoCommon/RenderBase.h
@@ -85,7 +85,7 @@ public:
 
 	static void SetWindowSize(int width, int height);
 
-	static void DrawLuaText(std::string text, int left, int top, u32 color);
+	static void DrawLuaText(std::string text, int left, int top, u32 color, int size);
 
 	// EFB coordinate conversion functions
 
@@ -110,7 +110,7 @@ public:
 	static void SetScreenshot(const std::string& filename);
 	static void DrawDebugText();
 
-	virtual void RenderText(const std::string& text, int left, int top, u32 color) = 0;
+	virtual void RenderText(const std::string& text, int left, int top, u32 color, int size = 11) = 0;
 
 	virtual void ClearScreen(const EFBRectangle& rc, bool colorEnable, bool alphaEnable, bool zEnable, u32 color, u32 z) = 0;
 	virtual void ReinterpretPixelData(unsigned int convtype) = 0;


### PR DESCRIPTION
These are commits cherry-picked from Xander's fork.

Feature changes:
- Lua controller function calls now apply to all controllers by default
- Lua controller functions now accept a controllerID as an argument
- Lua controller functions now work for WiiMotes and extensions (not Classic Controller yet)
- RenderText allows you to modify position, size, color of text drawn on-screen (I particularly am hopeful that this feature will allow for more intuitive on-screen displays)
- Get Wiimote decryption key
- Set IR values via bytes