### PR TITLE
Update UI on Lua framedump toggle, update README

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -43,6 +43,8 @@ SetScreenText(message as String) //Displays Text on Screen
 RenderText(text, start_x, start_y, colour, size) // Displays custom text on screen. (0,0) is the top left. Colour is the hex code 0xRRGGBB. The regular size is 11.
 
 CancelScript() //Cancels the script
+
+SetFrameAndAudioDump(enable as Boolean) // enables or disables frame and audio dumping
 ```
 
 For the following input/controller functions:

--- a/Source/Core/Core/LUA/Lua.cpp
+++ b/Source/Core/Core/LUA/Lua.cpp
@@ -44,8 +44,7 @@
 #include "VideoCommon/RenderBase.h"
 #include "Core/Host.h"
 
-//#include "DolphinWX/Main.h"
-//#include "DolphinWX/Frame.h"
+#include "DolphinWX/Frame.h"
 
 static const int ANY_CONTROLLER = -1;
 static const int NUNCHUK = 1;
@@ -595,8 +594,11 @@ int SetFrameAndAudioDump(lua_State* L)
 	bool enableDump = (lua_toboolean(L, 1) != 0);
 	SConfig::GetInstance().m_DumpFrames = enableDump;
 	SConfig::GetInstance().m_DumpAudio = enableDump;
-	//main_frame->GetMenuBar()->FindItem(IDM_TOGGLE_DUMP_FRAMES)->Check(enableDump);
-	//main_frame->GetMenuBar()->FindItem(IDM_TOGGLE_DUMP_AUDIO)->Check(enableDump);    
+
+	// Update UI menu checkboxes
+	wxGetApp().GetCFrame()->GetMenuBar()->FindItem(IDM_TOGGLE_DUMP_FRAMES)->Check(enableDump);
+	wxGetApp().GetCFrame()->GetMenuBar()->FindItem(IDM_TOGGLE_DUMP_AUDIO)->Check(enableDump);
+
 	SConfig::GetInstance().SaveSettings();
 
 	return 0;


### PR DESCRIPTION
@luckytyphlosion added a commit over a year ago to enable framedump/audiodump via a Lua function call. This simply revises functionality to update the UI menu checkboxes, as well as reflect the function in the README so users are aware of its existence.